### PR TITLE
Add missing graphs in person detection notebook

### DIFF
--- a/examples/person-detection/person_detection.py
+++ b/examples/person-detection/person_detection.py
@@ -91,4 +91,12 @@ metrics.show_executed_instructions(parser)
 
 # %%
 metrics.configure_plotly_browser_state()
+metrics.show_memory_access(parser)
+
+# %%
+metrics.configure_plotly_browser_state()
 metrics.show_exceptions(parser)
+
+# %%
+metrics.configure_plotly_browser_state()
+metrics.show_peripheral_access(parser)


### PR DESCRIPTION
This PR adds missing graphs (memory and peripherals) in person detection notebook.